### PR TITLE
Add Heroku and Links for Other PaaS Providers

### DIFF
--- a/_posts/16-05-01-PHP-PaaS-Providers.md
+++ b/_posts/16-05-01-PHP-PaaS-Providers.md
@@ -5,6 +5,7 @@ anchor:  php_paas_providers
 
 ## PHP PaaS Providers {#php_paas_providers_title}
 
-* Forge
-* Fortrabbit
-* PagodaBox
+* [Forge](https://forge.laravel.com/)
+* [Fortrabbit](http://www.fortrabbit.com/)
+* [PagodaBox](https://pagodabox.io/)
+* [Heroku](https://www.heroku.com/)


### PR DESCRIPTION
Quick Suggestion: How about you rename this to `Laravel PaaS Providers` and limit this to just Laravel friendly providers.
