### PR TITLE
Issue #33 - Fix bug of wrong URL "https://rebuildinglaravel.com/".

### DIFF
--- a/_posts/03-03-01-how-it-works.md
+++ b/_posts/03-03-01-how-it-works.md
@@ -5,6 +5,6 @@ anchor:  howitworks
 
 ## How Laravel Works? {#howitworks_title}
 
-Christopher Pitt has impressive explanation of the inner workings of Laravel, you can check it out in [https://rebuildinglaravel.com/] [rebuild-laravel-url]
+Christopher Pitt has impressive explanation of the inner workings of Laravel, you can check it out in [http://rebuildinglaravel.com/] [rebuild-laravel-url]
 
-[rebuild-laravel-url]: https://rebuildinglaravel.com/
+[rebuild-laravel-url]: http://rebuildinglaravel.com/


### PR DESCRIPTION
This is a pull-request for #33. It fixes the wrong URL "https://rebuildinglaravel.com/" in [_posts/03-03-01-how-it-works.md](https://github.com/laraveltherightway/laraveltherightway.github.io/blob/master/_posts/03-03-01-how-it-works.md) at line 8 and line 9.

If I missed any contribution guidelines, please let me know and I'll fix it as soon as possible, thank you!
