### PR TITLE
Added Cloudways PaaS provider

### DIFF
--- a/_posts/16-05-01-php-paas-providers.md
+++ b/_posts/16-05-01-php-paas-providers.md
@@ -9,3 +9,4 @@ anchor:  php_paas_providers
 * [Fortrabbit](http://www.fortrabbit.com/)
 * [PagodaBox](https://pagodabox.io/)
 * [Heroku](https://www.heroku.com/)
+* [Cloudways](https://www.cloudways.com/)


### PR DESCRIPTION
Cloudways is a managed cloud host provider which provide hosting for PHP based sites including Laravel.
