### PR TITLE
Fix 'good example' pivot table name

### DIFF
--- a/_posts/05-02-19-table-fields-naming.md
+++ b/_posts/05-02-19-table-fields-naming.md
@@ -43,7 +43,7 @@ Good
 
 ```
 post_user
-articles_user
+article_user
 photo_post
 ```
 


### PR DESCRIPTION
On Database Conventions > Table and Fields Naming > Pivot table, the Good examples include 'articles_user'.

I believe this should be 'article_user' (articles -> article) instead, due to singular naming conventions for pivot tables.

(I made this commit/PR using the GitHub site, and it also automatically did something on line 102 (with the \`\`\`). Not really sure what was going on here. If you want a new PR without this change, let me know. Although it shouldn't break anything.)